### PR TITLE
Possibility to set string and ast in 'where' for one query

### DIFF
--- a/lib/ecdo/builder/where.ex
+++ b/lib/ecdo/builder/where.ex
@@ -27,6 +27,8 @@ defmodule Ecdo.Builder.Where do
   defp build_conditions({op, _, _} = opspec, ecdo) when op in @allowed_operations_with_funs do
     %QueryExpr{expr: op_ast(opspec, ecdo)}
   end
+  defp build_conditions(where, ecdo) when is_binary(where), 
+    do: List.first build(where, ecdo)
 
   defp op_ast({op, left, right}, ecdo) do
     # Build from condition list an AST

--- a/test/ecdo_query_test.exs
+++ b/test/ecdo_query_test.exs
@@ -154,8 +154,8 @@ defmodule Ecdo.Integration.QueryTest do
   end
 
   test "like" do
-    TestRepo.insert!(%Post{title: "abcd"})
-    TestRepo.insert!(%Post{title: "adee"})
+    TestRepo.insert!(%Post{title: "abcd", visits: 10})
+    TestRepo.insert!(%Post{title: "adee", visits: 100})
 
     query = query({"p", Post}, %{select: "title", where: "like(title, \"%bc%\")", select_as: :one} )
     assert "abcd" == TestRepo.one(query)
@@ -166,5 +166,10 @@ defmodule Ecdo.Integration.QueryTest do
     query = query({"p", Post}, %{select: "title", where: [{:or, {:or, {:like, "title", "%bc%"}, {:like, "title", "%de%"}},
                                                                 {:like, "title", "%d%"}}], select_as: :list} )
     assert [["abcd"], ["adee"]] == TestRepo.all(query)
+
+    query = query({"p", Post}, %{select: "title", where: ["visits > 50", 
+                                                          {:or, {:or, {:like, "title", "%bc%"}, {:like, "title", "%de%"}},
+                                                                {:like, "title", "%d%"}}], select_as: :list} )
+    assert [["adee"]] == TestRepo.all(query)
   end
 end


### PR DESCRIPTION
Like this:

``` elixir
["visits > 50", 
 {:or, {:or, {:like, "title", "%bc%"}, {:like, "title", "%de%"}},
       {:like, "title", "%d%"}}]
```
